### PR TITLE
feat(order): an offer may not exceed the asking price

### DIFF
--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -8971,6 +8971,8 @@ paths:
         post:
             description: |
                 The buyer opens it, from the listing page: a seller has nobody to propose to on their own listing, so they answer rather than start. One active negotiation per (buyer, variant); the terms are then revised in place rather than by stacking rows, and each revision posts a card into the pair's chat thread.
+
+                `total` may not exceed the variant's listed price for that `quantity`. Negotiation only moves the price down: the asking price is already an offer to sell at it, so terms above it are a proposal with no reason to exist — the buyer would simply buy.
             requestBody:
                 content:
                     application/json:
@@ -9007,6 +9009,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: An active negotiation already exists for this (buyer, SKU)
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: '`total` is above the listed price for that `quantity`, or the listing is not negotiable'
             security:
                 - bearerAuth: []
             summary: Open a price negotiation on a variant
@@ -9067,6 +9075,8 @@ paths:
         patch:
             description: |
                 Revises the current terms in place, moves authorship to the caller and posts the new card into the thread. Only the party that does not own the standing proposal may counter, so the two sides alternate.
+
+                A counter may go *up* — that is a seller holding out — but not above the variant's listed price for that `quantity`, the same ceiling opening one has. The price is read when the counter lands, so a seller who lowered their asking price mid-thread has lowered it here too.
             requestBody:
                 content:
                     application/json:
@@ -9103,6 +9113,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: Negotiation is no longer active
+                "422":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: '`total` is above the listed price for that `quantity`'
             security:
                 - bearerAuth: []
             summary: Counter-offer

--- a/internal/module/order/adapter/postgres/repo_integration_test.go
+++ b/internal/module/order/adapter/postgres/repo_integration_test.go
@@ -430,7 +430,7 @@ func TestInsertOffer_OneActivePerBuyerAndVariant(t *testing.T) {
 	}
 
 	// A counter revises the same row, and the terms that come back are the new ones.
-	if err := active.Counter(seller, 1, 90_000, "firm", time.Now(), 48*time.Hour); err != nil {
+	if err := active.Counter(seller, 1, 90_000, 100_000, "firm", time.Now(), 48*time.Hour); err != nil {
 		t.Fatalf("Counter: %v", err)
 	}
 	if err := r.SaveOffer(ctx, active, []string{domain.OfferActive}); err != nil {

--- a/internal/module/order/api/openapi/offer.yaml
+++ b/internal/module/order/api/openapi/offer.yaml
@@ -22,6 +22,11 @@ paths:
         listing, so they answer rather than start. One active negotiation per (buyer, variant); the
         terms are then revised in place rather than by stacking rows, and each revision posts a card
         into the pair's chat thread.
+
+
+        `total` may not exceed the variant's listed price for that `quantity`. Negotiation only
+        moves the price down: the asking price is already an offer to sell at it, so terms above
+        it are a proposal with no reason to exist — the buyer would simply buy.
       security: [{ bearerAuth: [] }]
       requestBody:
         required: true
@@ -43,6 +48,7 @@ paths:
         '403': { description: 'A seller cannot open a negotiation on their own listing', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
         '404': { $ref: '#/components/responses/NotFound' }
         '409': { description: 'An active negotiation already exists for this (buyer, SKU)', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '422': { description: '`total` is above the listed price for that `quantity`, or the listing is not negotiable', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
     get:
       tags: [order]
       summary: List the caller's negotiations, both sides at once
@@ -89,6 +95,12 @@ paths:
         Revises the current terms in place, moves authorship to the caller and posts the new
         card into the thread. Only the party that does not own the standing proposal may
         counter, so the two sides alternate.
+
+
+        A counter may go *up* — that is a seller holding out — but not above the variant's
+        listed price for that `quantity`, the same ceiling opening one has. The price is read
+        when the counter lands, so a seller who lowered their asking price mid-thread has
+        lowered it here too.
       security: [{ bearerAuth: [] }]
       requestBody:
         required: true
@@ -110,6 +122,7 @@ paths:
         '403': { description: 'Caller already owns the standing proposal, or is not a party', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
         '404': { $ref: '#/components/responses/NotFound' }
         '409': { description: 'Negotiation is no longer active', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
+        '422': { description: '`total` is above the listed price for that `quantity`', content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } } }
     delete:
       tags: [order]
       summary: Cancel a negotiation

--- a/internal/module/order/domain/errors.go
+++ b/internal/module/order/domain/errors.go
@@ -46,6 +46,13 @@ var (
 	// price; only the buyer turns it into an order, because only the buyer pays.
 	ErrOnlyBuyerCheckout = errx.NewError(http.StatusForbidden, "only_buyer_checkout", "only the buyer checks out agreed terms")
 	ErrFixedPriceListing = errx.NewError(http.StatusUnprocessableEntity, "fixed_price_listing", "this listing is not negotiable")
+	// ErrOfferAboveAsking is terms worth more than the listing asks for that quantity.
+	// Negotiation on this platform only ever moves the price down: the asking price is
+	// already an offer to sell at it, so anything above it is a proposal neither side has
+	// a reason to make — and one nobody would need this route for, since the buyer can
+	// simply buy. Held for both parties, because a seller countering above their own
+	// asking price is the same nonsense from the other end.
+	ErrOfferAboveAsking = errx.NewError(http.StatusUnprocessableEntity, "offer_above_asking", "an offer cannot be above the asking price")
 
 	// --- orders ---
 	ErrOrderNotFound = errx.NewError(http.StatusNotFound, "order_not_found", "order not found")

--- a/internal/module/order/domain/offer.go
+++ b/internal/module/order/domain/offer.go
@@ -56,6 +56,11 @@ type NewTerms struct {
 	Quantity  int64
 	Total     int64
 	Reason    string
+	// UnitPrice is what the variant is listed at, and the ceiling the terms have to sit
+	// under. Zero means the caller could not resolve one, and then nothing is enforced —
+	// refusing every offer because a price lookup came back empty would be worse than the
+	// rule it is protecting.
+	UnitPrice int64
 }
 
 // NewOffer opens a negotiation. The buyer starts it — a seller has nobody to propose to on their
@@ -70,10 +75,27 @@ func NewOffer(in NewTerms, window time.Duration) (Offer, error) {
 	if in.BuyerID == in.SellerID {
 		return Offer{}, ErrSellerCannotOffer
 	}
+	if !WithinAsking(in.Quantity, in.Total, in.UnitPrice) {
+		return Offer{}, ErrOfferAboveAsking
+	}
 	if err := validation.Default().Struct(o); err != nil {
 		return Offer{}, validation.AsError(err)
 	}
 	return o, nil
+}
+
+// WithinAsking reports whether terms sit at or under what the listing asks for that quantity.
+//
+// The comparison is on the total rather than on a derived unit price, because the total is
+// what either side actually types and what the escrow will hold — dividing it by the quantity
+// first would let a rounded-down unit price pass a total that is over the line.
+//
+// An unknown asking price (zero) permits everything: see [NewTerms.UnitPrice].
+func WithinAsking(quantity, total, unitPrice int64) bool {
+	if unitPrice <= 0 || quantity <= 0 {
+		return true
+	}
+	return total <= unitPrice*quantity
 }
 
 // Live reports whether the negotiation is still open to a move.
@@ -89,7 +111,11 @@ func (o Offer) Involves(accountID int64) bool {
 // Counter revises the terms and moves authorship. Only the party that does not own the
 // standing proposal may counter, so the two sides alternate and a price on the table is
 // always somebody else's to answer.
-func (o *Offer) Counter(actorID, quantity, total int64, reason string, now time.Time, window time.Duration) error {
+//
+// [unitPrice] is the variant's listed price, and the same ceiling [NewOffer] holds: a counter
+// is the other half of the same negotiation, and a rule enforced only when a case is opened is
+// a rule with one move around it.
+func (o *Offer) Counter(actorID, quantity, total, unitPrice int64, reason string, now time.Time, window time.Duration) error {
 	if err := o.movable(actorID, now); err != nil {
 		return err
 	}
@@ -98,6 +124,9 @@ func (o *Offer) Counter(actorID, quantity, total int64, reason string, now time.
 	}
 	if quantity <= 0 || total <= 0 {
 		return errQuantityPositive
+	}
+	if !WithinAsking(quantity, total, unitPrice) {
+		return ErrOfferAboveAsking
 	}
 	o.AuthorID, o.Quantity, o.Total = actorID, quantity, total
 	if reason != "" {

--- a/internal/module/order/domain/order_test.go
+++ b/internal/module/order/domain/order_test.go
@@ -263,20 +263,77 @@ func TestRefund_EscalatableStates(t *testing.T) {
 	}
 }
 
+// Negotiation only moves the price down. The asking price is already an offer to sell at it,
+// so terms above it are a proposal with no reason to exist — the buyer would simply buy.
+func TestOffer_NotAboveAskingPrice(t *testing.T) {
+	const buyer, seller = int64(7), int64(8)
+	const asking = int64(100_000)
+
+	terms := func(total int64, quantity int64) domain.NewTerms {
+		return domain.NewTerms{
+			ListingID: 1, VariantID: 2, BuyerID: buyer, SellerID: seller,
+			Quantity: quantity, Total: total, UnitPrice: asking,
+		}
+	}
+
+	if _, err := domain.NewOffer(terms(120_000, 1), time.Hour); !errors.Is(err, domain.ErrOfferAboveAsking) {
+		t.Fatalf("opening above asking = %v, want ErrOfferAboveAsking", err)
+	}
+	// Exactly the asking price is not above it.
+	if _, err := domain.NewOffer(terms(asking, 1), time.Hour); err != nil {
+		t.Fatalf("opening at asking: %v", err)
+	}
+	// The ceiling scales with the quantity, and the comparison is on the total: three units
+	// at the asking price is fine, one đồng more is not.
+	if _, err := domain.NewOffer(terms(3*asking, 3), time.Hour); err != nil {
+		t.Fatalf("opening at asking for three: %v", err)
+	}
+	if _, err := domain.NewOffer(terms(3*asking+1, 3), time.Hour); !errors.Is(err, domain.ErrOfferAboveAsking) {
+		t.Fatalf("opening a đồng above asking for three = %v, want ErrOfferAboveAsking", err)
+	}
+
+	// And the same ceiling on the answer, from the other side: a rule the counter route did
+	// not hold would be one move away from being no rule.
+	o, err := domain.NewOffer(terms(80_000, 1), time.Hour)
+	if err != nil {
+		t.Fatalf("NewOffer: %v", err)
+	}
+	now := time.Now()
+	if err := o.Counter(seller, 1, 120_000, asking, "firm", now, time.Hour); !errors.Is(err, domain.ErrOfferAboveAsking) {
+		t.Fatalf("countering above asking = %v, want ErrOfferAboveAsking", err)
+	}
+	if o.Total != 80_000 || o.AuthorID != buyer {
+		t.Fatalf("offer = %+v, want the refused counter to have changed nothing", o)
+	}
+
+	// An asking price the caller could not resolve enforces nothing, rather than refusing
+	// every negotiation on a listing whose price lookup came back empty.
+	if _, err := domain.NewOffer(domain.NewTerms{
+		ListingID: 1, VariantID: 2, BuyerID: buyer, SellerID: seller,
+		Quantity: 1, Total: 999_000,
+	}, time.Hour); err != nil {
+		t.Fatalf("opening with no known asking price: %v", err)
+	}
+}
+
 // A negotiation alternates: the side holding the standing proposal cannot answer itself, and
 // only the buyer closes it.
 func TestOffer_AlternatesAndOnlyBuyerAccepts(t *testing.T) {
 	const buyer, seller = int64(7), int64(8)
-	o, err := domain.NewOffer(domain.NewTerms{ListingID: 1, VariantID: 2, BuyerID: buyer, SellerID: seller, Quantity: 1, Total: 100_000, Reason: ""}, time.Hour)
+	// The listing asks 150_000; every move below happens under that ceiling.
+	const asking = int64(150_000)
+	o, err := domain.NewOffer(domain.NewTerms{ListingID: 1, VariantID: 2, BuyerID: buyer, SellerID: seller, Quantity: 1, Total: 100_000, Reason: "", UnitPrice: asking}, time.Hour)
 	if err != nil {
 		t.Fatalf("NewOffer: %v", err)
 	}
 	now := time.Now()
 	// The buyer opened it, so answering is the seller's move.
-	if err := o.Counter(buyer, 1, 90_000, "", now, time.Hour); !errors.Is(err, domain.ErrNotYourTurn) {
+	if err := o.Counter(buyer, 1, 90_000, asking, "", now, time.Hour); !errors.Is(err, domain.ErrNotYourTurn) {
 		t.Fatalf("countering one's own = %v, want ErrNotYourTurn", err)
 	}
-	if err := o.Counter(seller, 1, 120_000, "firm", now, time.Hour); err != nil {
+	// A counter may go *up* — that is the seller holding out — as long as it stays at or
+	// under what the listing asks.
+	if err := o.Counter(seller, 1, 120_000, asking, "firm", now, time.Hour); err != nil {
 		t.Fatalf("Counter: %v", err)
 	}
 	if o.AuthorID != seller || o.Total != 120_000 {

--- a/internal/module/order/service_offer.go
+++ b/internal/module/order/service_offer.go
@@ -67,7 +67,7 @@ const (
 // row's, and the message carries only the offer's id so a counter cannot leave an old price
 // on screen.
 func (s *Service) CreateOffer(ctx context.Context, req orderapi.CreateOfferRequest) (orderapi.Offer, error) {
-	listing, _, err := s.variantOf(ctx, req.ActorID, req.VariantID)
+	listing, variant, err := s.variantOf(ctx, req.ActorID, req.VariantID)
 	if err != nil {
 		return orderapi.Offer{}, err
 	}
@@ -88,6 +88,7 @@ func (s *Service) CreateOffer(ctx context.Context, req orderapi.CreateOfferReque
 		Quantity:  req.Quantity,
 		Total:     req.Total,
 		Reason:    req.Reason,
+		UnitPrice: variant.Price,
 	}, offerWindow)
 	if err != nil {
 		return orderapi.Offer{}, err
@@ -179,7 +180,14 @@ func (s *Service) CounterOffer(ctx context.Context, req orderapi.CounterOfferReq
 	if err != nil {
 		return orderapi.Offer{}, err
 	}
-	if err := o.Counter(req.ActorID.Int64(), req.Quantity, req.Total, req.Reason, time.Now(), offerWindow); err != nil {
+	// The ceiling is read now rather than frozen when the negotiation opened: a seller who
+	// drops their asking price mid-thread has lowered it for the counter too, and the row
+	// carries no copy of the price to go stale.
+	_, variant, err := s.variantOf(ctx, req.ActorID, id.Of[id.Variant](o.VariantID))
+	if err != nil {
+		return orderapi.Offer{}, err
+	}
+	if err := o.Counter(req.ActorID.Int64(), req.Quantity, req.Total, variant.Price, req.Reason, time.Now(), offerWindow); err != nil {
 		return orderapi.Offer{}, err
 	}
 	// From `active` only: a counter that read the row before somebody else's acceptance landed


### PR DESCRIPTION
## Luật

Thương lượng chỉ đi xuống. Giá niêm yết vốn đã là lời đề nghị bán ở mức đó, nên một đề xuất *cao hơn* nó là thứ không bên nào có lý do gõ — và cũng không cần route này, vì người mua chỉ việc bấm mua.

Giữ ở **cả hai route** và cho **cả hai bên**: mở một thương lượng và trả giá là hai nửa của cùng một việc, và một luật chỉ áp lúc mở là một luật có đúng một nước đi vòng qua nó. Người bán trả giá cao hơn chính giá niêm yết của mình cũng là chuyện vô lý y hệt từ đầu kia.

## Vài quyết định

- **Trần đọc lúc nước đi hạ xuống**, không đóng băng lúc mở thương lượng: người bán hạ giá niêm yết giữa chừng thì đã hạ cho cả lượt trả giá. Hàng offer không giữ bản sao nào của giá để mà cũ đi.
- **So trên tổng tiền**, không trên đơn giá suy ra: tổng là thứ hai bên gõ và là thứ escrow sẽ giữ, còn chia cho số lượng trước sẽ để một đơn giá làm tròn xuống cho lọt một tổng đã vượt.
- **Không tra được giá niêm yết (0) thì không chặn gì**: từ chối mọi thương lượng vì một lượt đọc giá về rỗng còn tệ hơn chính cái luật nó bảo vệ.

## Kiểm

`TestOffer_NotAboveAskingPrice` phủ: mở trên trần bị từ chối, đúng bằng trần thì qua, trần nhân theo số lượng, trả giá trên trần bị từ chối **và không đổi gì trên hàng**, giá niêm yết không rõ thì không chặn.

`go test ./...` xanh (49 package). `api/openapi.gen.yaml` đã chạy lại.

Client: shopnexus/app#17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)